### PR TITLE
Update github-connector.yml

### DIFF
--- a/serverless-lambda/harnesscd-pipeline/github-connector.yml
+++ b/serverless-lambda/harnesscd-pipeline/github-connector.yml
@@ -14,11 +14,11 @@ connector:
         type: UsernameToken
         spec:
           username: <Enter Your Github Username>
-          tokenRef: harnessgitpat
+          tokenRef: harness_gitpat
     apiAccess:
       type: Token
       spec:
-        tokenRef: harnessgitpat
+        tokenRef: harness_gitpat
     delegateSelectors:
       - harness-serverless-delegate
     executeOnDelegate: true


### PR DESCRIPTION
serverless github connector had wrong/diff naming for secret name as per doc https://developer.harness.io/tutorials/cd-pipelines/serverless/aws-lambda/#github-secret